### PR TITLE
chore(nix): update `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1683134812,
-        "narHash": "sha256-yUiArtneEBCTYt7rOg/tLr1iv4AmjFu5tdGa0OVpjbo=",
+        "lastModified": 1684455135,
+        "narHash": "sha256-Y4mhlwvjYgYs6moC2ERjm1XeiSQCvvSEDSpg9agL+PA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8708b19627b2dfc2d1ac332b74383b8abdd429f0",
+        "rev": "2f8dd307c55ca383a4aeb8ccd5ae250ae8db72e4",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1683267728,
-        "narHash": "sha256-V370or77sffDQ2U1XnWUJKH1ahZFvOYt+wOCi+npaZ4=",
+        "lastModified": 1684390923,
+        "narHash": "sha256-8LSe1K8ua8uyqc0B8wsQEY9qNCTX2h78mzUt2A7Uqhg=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "b520294e3604f424458d6af881263854f0545f79",
+        "rev": "8a69206e50ca6a2cc4ae7a22eef4bfcbe6dbc9f6",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683194677,
-        "narHash": "sha256-Am7aCGNy/h6RMnvg7Pn4PHQXZZq9FyIUA9klYxBwyDI=",
+        "lastModified": 1684385584,
+        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d8145a5d81ebf6698077b21042380a3a66a11c7",
+        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1683226024,
-        "narHash": "sha256-F9ZVlVKqdlA0wGZKvQNGc/z398YuR0PgYuKLJXmL5w0=",
+        "lastModified": 1684145961,
+        "narHash": "sha256-Ms99ML1P53EC50TnznmV55QwhOJtql75BbXfyiGuFvU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "0dd94d3b078fa524272f942f69239a9564532fe1",
+        "rev": "2f8cd66fb4c98026d2bdbdf17270e3472e1ca42a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/8708b19627b2dfc2d1ac332b74383b8abdd429f0' (2023-05-03)
  → 'github:ipetkov/crane/2f8dd307c55ca383a4aeb8ccd5ae250ae8db72e4' (2023-05-19)
• Updated input 'fenix':
    'github:nix-community/fenix/b520294e3604f424458d6af881263854f0545f79' (2023-05-05)
  → 'github:nix-community/fenix/8a69206e50ca6a2cc4ae7a22eef4bfcbe6dbc9f6' (2023-05-18)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/0dd94d3b078fa524272f942f69239a9564532fe1' (2023-05-04)
  → 'github:rust-lang/rust-analyzer/2f8cd66fb4c98026d2bdbdf17270e3472e1ca42a' (2023-05-15)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0d8145a5d81ebf6698077b21042380a3a66a11c7' (2023-05-04)
  → 'github:NixOS/nixpkgs/48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a' (2023-05-18)
