### PR TITLE
chore(nix): update `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1690870967,
-        "narHash": "sha256-zIlq3ls5qSuMVKFKKkR+s30L84tP1iiG3OSq0jkszpw=",
+        "lastModified": 1690957271,
+        "narHash": "sha256-//ItnqqVI6M5nrnQbpZ/a93S65YosvSSn8ozqEQOgQo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "260b00254fc152885283b0d2aec78547a1f77efd",
+        "rev": "90aba0cc6f4c30a8f4111a0c4baf548bae5d9510",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690789960,
-        "narHash": "sha256-3K+2HuyGTiJUSZNJxXXvc0qj4xFx1FHC/ItYtEa7/Xs=",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb942492b7accdee4e6d17f5447091c65897dde4",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1690816174,
-        "narHash": "sha256-w+lIxLQjCjt4ABS7V5YhgVVoCfBBphAFLi9lahjuWA4=",
+        "lastModified": 1690888982,
+        "narHash": "sha256-MQniEaKbxsewuXGo+DaFE1IODeodExYHolPhUTrMoLc=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "8202b5aaa7739eb9aa7a0c6a375857c971357748",
+        "rev": "151c750dac8d2a03a4a1f9c20d2fc29ad2042f02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'fenix':
    'github:nix-community/fenix/260b00254fc152885283b0d2aec78547a1f77efd' (2023-08-01)
  → 'github:nix-community/fenix/90aba0cc6f4c30a8f4111a0c4baf548bae5d9510' (2023-08-02)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/8202b5aaa7739eb9aa7a0c6a375857c971357748' (2023-07-31)
  → 'github:rust-lang/rust-analyzer/151c750dac8d2a03a4a1f9c20d2fc29ad2042f02' (2023-08-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/fb942492b7accdee4e6d17f5447091c65897dde4' (2023-07-31)
  → 'github:NixOS/nixpkgs/9e1960bc196baf6881340d53dccb203a951745a2' (2023-08-01)
